### PR TITLE
fix so that results for all 1536 index pairs are returned

### DIFF
--- a/code/countAmpliconsAWS.R
+++ b/code/countAmpliconsAWS.R
@@ -68,7 +68,7 @@ results <- read_csv("results.csv") %>%
                 index = i1,
                 index2 = i2) %>% 
   mutate(mergedIndex = paste0(index, index2)) %>% 
-  left_join(ss, by = c("mergedIndex","index","index2"))
+  full_join(ss, by = c("mergedIndex","index","index2"))
 
 
 # Add levels to indices for index swapping plots


### PR DESCRIPTION
Changed `left_join` to `full_join` so that results for all index pairs are returned, even if there were 0 reads observed for a given targeted index pair. 

This will fix the _Unknown_ values in the _Sequencing Result_ column as well as missing values in the plate map plots and will be classified as _failed: low S2 & RPP30_.