### PR TITLE
don't return unnecessary files

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -84,9 +84,6 @@ def do_analysis(rundir, basespace_id, threads=8, season=None, debug=False):
 
     attachments = {
         'LIMS_results.csv': b64encode_file(f"{rundir}/LIMS_results.csv"),
-        'run_info.csv': b64encode_file(f"{rundir}/run_info.csv"),
-        'countTable.csv': b64encode_file(f"{rundir}/countTable.csv"),
-        'SampleSheet.csv': b64encode_file(f"{rundir}/SampleSheet.csv"),
     }
     for pdf_attachment in glob.glob(f"{rundir}/*.pdf"):
         attachments[os.path.basename(pdf_attachment)] = b64encode_file(pdf_attachment)

--- a/api/swabseq.py
+++ b/api/swabseq.py
@@ -15,9 +15,6 @@ api = Namespace('swabseq', description='Operations for Swabseq sequence data ana
 swabseq_result = api.model('SwabseqResult', {})
 swabseq_attachments = api.model('SwabseqAttachments', {
     'LIMS_results.csv': fields.String(),
-    'run_info.csv': fields.String(),
-    'countTable.csv': fields.String(),
-    'SampleSheet.csv': fields.String(),
 })
 swabseq_output = api.model('SwabseqOutput', {
     'id': fields.String(),


### PR DESCRIPTION
We only need the .pdf and the LIMS_results.csv files to be returned.